### PR TITLE
Fixed the Build Issue by adding Suspense in Client Components

### DIFF
--- a/apps/web/app/auth/layout.tsx
+++ b/apps/web/app/auth/layout.tsx
@@ -25,14 +25,16 @@ export default function AuthLayout({
   }, []);
 
   return (
-    <GuestGuard>
-      <div className="h-screen flex">
-        <div
-          className="w-1/2 bg-cover bg-center"
-          style={{ backgroundImage: `url(${bgImage})` }}
-        ></div>
-        <div className="w-1/2">{children}</div>
-      </div>
-    </GuestGuard>
+    <React.Suspense fallback={<div>Loading...</div>}>
+      <GuestGuard>
+        <div className="h-screen flex">
+          <div
+            className="w-1/2 bg-cover bg-center"
+            style={{ backgroundImage: `url(${bgImage})` }}
+          ></div>
+          <div className="w-1/2">{children}</div>
+        </div>
+      </GuestGuard>
+    </React.Suspense>
   );
 }

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -1,14 +1,5 @@
 'use client';
 
-// import dynamic from 'next/dynamic';
-
-// const AuthPage = dynamic(
-//   () => import('@/sections/auth/main').then((mod) => mod.AuthMain),
-//   { ssr: false },
-// );
-
-// export default AuthPage;
-
 import { Suspense } from 'react';
 import LoginPage from './login';
 


### PR DESCRIPTION
# Problem Explanation

- This error occurs because useSearchParams() in Next.js App Router must be wrapped in a <Suspense> boundary when used inside Client Components.
- Since `useSearchParams()` is an asynchronous hook, and Next.js requires `Suspense` to handle it properly.

# Solution/ Changes made
- A <Suspense> boundary was added at the guard route level to ensure proper hydration and avoid runtime errors.
- This approach ensures that the page remains prerender-friendly while still leveraging useSearchParams() inside Client Components.
