### PR TITLE
Toast message display

### DIFF
--- a/apps/web/layouts/admin/layout.tsx
+++ b/apps/web/layouts/admin/layout.tsx
@@ -6,6 +6,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@rumsan/shadcn-ui/components/sidebar';
+import { Toaster } from '@rumsan/shadcn-ui/components/toaster';
 import { ReactNode } from 'react';
 
 export default function AdminLayout({
@@ -27,6 +28,7 @@ export default function AdminLayout({
               <div className="text-lg font-bold">{title}</div>
             </div>
           </header>
+          <Toaster />
           <>{children}</>
         </SidebarInset>
       </SidebarProvider>

--- a/apps/web/sections/accounts/form/accounts.add.tsx
+++ b/apps/web/sections/accounts/form/accounts.add.tsx
@@ -24,6 +24,7 @@ export function AccountAdd({ children }: { children: ReactNode }) {
     try {
       await addAccount.mutateAsync(data);
       toast({
+        variant: 'success',
         description: 'Account added successfully',
       });
       setDialogOpen(false);

--- a/apps/web/sections/accounts/form/accounts.add.tsx
+++ b/apps/web/sections/accounts/form/accounts.add.tsx
@@ -29,6 +29,10 @@ export function AccountAdd({ children }: { children: ReactNode }) {
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to add account:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to add account',
+      });
     }
   };
 

--- a/apps/web/sections/accounts/form/accounts.edit.tsx
+++ b/apps/web/sections/accounts/form/accounts.edit.tsx
@@ -36,6 +36,10 @@ export function AccountEdit({ row, isOpen, onClose }: AccountEditProps) {
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to edit account:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to edit account',
+      });
     }
   };
 

--- a/apps/web/sections/accounts/form/accounts.edit.tsx
+++ b/apps/web/sections/accounts/form/accounts.edit.tsx
@@ -31,6 +31,7 @@ export function AccountEdit({ row, isOpen, onClose }: AccountEditProps) {
         console.error('Account ID is undefined');
       }
       toast({
+        variant: 'success',
         description: 'Account updated successfully',
       });
       setDialogOpen(false);

--- a/apps/web/sections/category/form/categories.form.tsx
+++ b/apps/web/sections/category/form/categories.form.tsx
@@ -83,7 +83,7 @@ export function CommonCategoryForm({
               <Select onValueChange={field.onChange} value={field.value}>
                 <FormControl>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select category name" />
+                    <SelectValue placeholder="Select group" />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>

--- a/apps/web/sections/category/form/category.add.tsx
+++ b/apps/web/sections/category/form/category.add.tsx
@@ -24,6 +24,7 @@ export function CategoryAdd({ children }: { children: ReactNode }) {
     try {
       await addCategory.mutateAsync(data);
       toast({
+        variant: 'success',
         description: 'Category added successfully',
       });
       setDialogOpen(false);

--- a/apps/web/sections/category/form/category.add.tsx
+++ b/apps/web/sections/category/form/category.add.tsx
@@ -29,6 +29,10 @@ export function CategoryAdd({ children }: { children: ReactNode }) {
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to add category:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to add category',
+      });
     }
   };
 

--- a/apps/web/sections/category/form/category.edit.tsx
+++ b/apps/web/sections/category/form/category.edit.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from '@rumsan/shadcn-ui/components/dialog';
 import { useToast } from '@rumsan/shadcn-ui/hooks/use-toast';
-import { useState } from 'react';
 import { CommonCategoryForm } from './categories.form';
 
 interface CategoryEditProps {
@@ -21,7 +20,6 @@ interface CategoryEditProps {
 export function CategoryEdit({ row, isOpen, onClose }: CategoryEditProps) {
   const { toast } = useToast();
   const editCategory = useEditCategory();
-  const [isDialogOpen, setDialogOpen] = useState(false);
 
   const onSubmit = async (data: EditCategory) => {
     try {
@@ -31,9 +29,10 @@ export function CategoryEdit({ row, isOpen, onClose }: CategoryEditProps) {
         console.error('Category ID is undefined');
       }
       toast({
+        variant: 'success',
         description: 'Category updated successfully',
       });
-      setDialogOpen(false);
+      onClose()
     } catch (error) {
       console.error('Failed to edit category:', error);
       toast({
@@ -58,7 +57,7 @@ export function CategoryEdit({ row, isOpen, onClose }: CategoryEditProps) {
           defaultValues={{ name: row.name, group: row.group }}
           isEdit={true}
           onCancel={() => {
-            setDialogOpen(false);
+            onClose()
           }}
         />
       </DialogContent>

--- a/apps/web/sections/category/form/category.edit.tsx
+++ b/apps/web/sections/category/form/category.edit.tsx
@@ -36,6 +36,10 @@ export function CategoryEdit({ row, isOpen, onClose }: CategoryEditProps) {
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to edit category:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to edit category',
+      });
     }
   };
 

--- a/apps/web/sections/deparment/form/department.add.tsx
+++ b/apps/web/sections/deparment/form/department.add.tsx
@@ -26,6 +26,7 @@ export function DepartmentAdd({ children }: { children: ReactNode }) {
     try {
       await addDepartment.mutateAsync(data);
       toast({
+        variant: 'success',
         description: 'Department added successfully',
       });
 

--- a/apps/web/sections/deparment/form/department.add.tsx
+++ b/apps/web/sections/deparment/form/department.add.tsx
@@ -32,6 +32,10 @@ export function DepartmentAdd({ children }: { children: ReactNode }) {
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to add department:', error);
+      toast({
+        variant: 'destructive',
+        description: 'Failed to add department',
+      });
     }
   };
 

--- a/apps/web/sections/deparment/form/department.edit.tsx
+++ b/apps/web/sections/deparment/form/department.edit.tsx
@@ -11,7 +11,6 @@ import {
 } from '@rumsan/shadcn-ui/components/dialog';
 import { useToast } from '@rumsan/shadcn-ui/hooks/use-toast';
 
-import { useState } from 'react';
 import { CommonDepartmentForm } from './department.form';
 
 interface DepartmentEditProps {
@@ -25,7 +24,6 @@ export function DepartmentEdit({
   isOpen,
   onClose,
 }: DepartmentEditProps): any {
-  const [isDialogOpen, setDialogOpen] = useState(false);
 
   const editDepartment = useEditDepartment();
   const { toast } = useToast();
@@ -36,10 +34,10 @@ export function DepartmentEdit({
         await editDepartment.mutateAsync({ id: row.cuid, data });
 
         toast({
+          variant: 'success',
           description: 'Department edited successfully',
         });
 
-        // setDialogOpen(false);
         onClose()
       } else {
         console.error('Department or its ID is undefined');

--- a/apps/web/sections/deparment/form/department.edit.tsx
+++ b/apps/web/sections/deparment/form/department.edit.tsx
@@ -39,7 +39,8 @@ export function DepartmentEdit({
           description: 'Department edited successfully',
         });
 
-        setDialogOpen(false);
+        // setDialogOpen(false);
+        onClose()
       } else {
         console.error('Department or its ID is undefined');
       }
@@ -67,7 +68,7 @@ export function DepartmentEdit({
           defaultValues={{ name: row.name, group: row.group, owner: row.owner }}
           isEdit={true}
           onCancel={() => {
-            setDialogOpen(false);
+            onClose()
           }}
         />
       </DialogContent>

--- a/apps/web/sections/projects/form/project.add.tsx
+++ b/apps/web/sections/projects/form/project.add.tsx
@@ -27,9 +27,9 @@ export function ProjectAdd({ children }: { children: ReactNode }) {
     try {
       await addProject.mutateAsync(data);
       toast({
+        variant: 'success',
         description: 'Project added successfully',
       });
-
       setDialogOpen(false);
     } catch (error) {
       console.error('Failed to add project:', error);

--- a/apps/web/sections/projects/form/project.edit.tsx
+++ b/apps/web/sections/projects/form/project.edit.tsx
@@ -11,7 +11,6 @@ import {
 } from '@rumsan/shadcn-ui/components/dialog';
 import { useToast } from '@rumsan/shadcn-ui/hooks/use-toast';
 
-import { useState } from 'react';
 import { CommonProjectForm } from './project.form';
 
 interface ProjectEditProps {
@@ -21,7 +20,6 @@ interface ProjectEditProps {
 }
 
 export function ProjectEdit({ row, isOpen, onClose }: ProjectEditProps) {
-  const [isDialogOpen, setDialogOpen] = useState(false);
 
   const editProject = useEditProject();
   const { toast } = useToast();
@@ -32,10 +30,11 @@ export function ProjectEdit({ row, isOpen, onClose }: ProjectEditProps) {
         await editProject.mutateAsync({ id: row.cuid, data });
 
         toast({
+          variant: 'success',
           description: 'Project edited successfully',
         });
 
-        setDialogOpen(false);
+        onClose()
       } else {
         console.error('project or its ID is undefined');
       }
@@ -68,7 +67,7 @@ export function ProjectEdit({ row, isOpen, onClose }: ProjectEditProps) {
           }}
           isEdit={true}
           onCancel={() => {
-            setDialogOpen(false);
+            onClose()
           }}
         />
       </DialogContent>

--- a/packages/shadcn-ui/src/components/sonner.tsx
+++ b/packages/shadcn-ui/src/components/sonner.tsx
@@ -21,6 +21,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+          success: "group-[.toast]:bg-success group-[.toast]:text-success-foreground",
         },
       }}
       {...props}

--- a/packages/shadcn-ui/src/components/toast.tsx
+++ b/packages/shadcn-ui/src/components/toast.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import * as ToastPrimitives from '@radix-ui/react-toast';
-import {cva, type VariantProps} from 'class-variance-authority';
-import {X} from 'lucide-react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
 import * as React from 'react';
 
-import {cn} from '@rumsan/shadcn-ui/lib/utils';
+import { cn } from '@rumsan/shadcn-ui/lib/utils';
 
 const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
@@ -30,9 +30,10 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: 'border bg-background text-foreground',
+        success: 'group border-success bg-success text-success-foreground',
         destructive:
           'destructive group border-destructive bg-destructive text-destructive-foreground',
-      },
+      }
     },
     defaultVariants: {
       variant: 'default',
@@ -43,12 +44,12 @@ const toastVariants = cva(
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants>
->(({className, variant, ...props}, ref) => {
+  VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
   return (
     <ToastPrimitives.Root
       ref={ref}
-      className={cn(toastVariants({variant}), className)}
+      className={cn(toastVariants({ variant }), className)}
       {...props}
     />
   );
@@ -58,7 +59,7 @@ Toast.displayName = ToastPrimitives.Root.displayName;
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
@@ -73,7 +74,7 @@ ToastAction.displayName = ToastPrimitives.Action.displayName;
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
@@ -91,7 +92,7 @@ ToastClose.displayName = ToastPrimitives.Close.displayName;
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
     className={cn('text-sm font-semibold [&+div]:text-xs', className)}
@@ -103,7 +104,7 @@ ToastTitle.displayName = ToastPrimitives.Title.displayName;
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
     className={cn('text-sm opacity-90', className)}
@@ -125,5 +126,6 @@ export {
   ToastTitle,
   ToastViewport,
   type ToastActionElement,
-  type ToastProps,
+  type ToastProps
 };
+

--- a/packages/shadcn-ui/src/styles/globals.css
+++ b/packages/shadcn-ui/src/styles/globals.css
@@ -1,9 +1,11 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
+
 body {
   font-family: 'DIN Alternate', sans-serif;
   font-size: 16px;
 }
+
 @import 'tailwindcss/utilities';
 
 @layer base {
@@ -24,6 +26,8 @@ body {
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    --success: 142 60% 40%;
+    --success-foreground: 142 100% 90%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 10% 3.9%;
@@ -42,6 +46,7 @@ body {
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
+
   .dark {
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
@@ -59,6 +64,8 @@ body {
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
+    --success: 142 55% 20%;
+    --success-foreground: 142 100% 90%;
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
@@ -82,6 +89,7 @@ body {
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/packages/shadcn-ui/tailwind.config.js
+++ b/packages/shadcn-ui/tailwind.config.js
@@ -38,6 +38,11 @@ const config = {
           DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',
         },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+
         accent: {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',


### PR DESCRIPTION
Added custom green color for success toast notifications in the global CSS and Tailwind config. The green color didn't show up until these changes were made. Also attempted to position the toast in the top-right corner, but due to time constraints, I was unable to finalize that part. Please review and merge.







